### PR TITLE
fix(ci): use legacy peer deps in CI installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         cache: 'npm'
     
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --legacy-peer-deps
     
     - name: Run linting
       run: npm run lint
@@ -59,7 +59,7 @@ jobs:
         cache: 'npm'
     
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --legacy-peer-deps
     
     - name: Build application
       run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         cache: 'npm'
     
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --legacy-peer-deps
     
     - name: Run linting
       run: npm run lint


### PR DESCRIPTION
Update GitHub Actions workflows to install dependencies with npm ci --legacy-peer-deps instead of npm ci. Apply the change in:
- .github/workflows/ci.yml (install steps for lint and build jobs)
- .github/workflows/test.yml (install step for lint job)

This addresses CI failures caused by peer dependency conflicts in the dependency tree. Using --legacy-peer-deps preserves the previous npm v6 install behavior so the workflow can complete without altering package dependency resolutions or requiring immediate package updates.